### PR TITLE
Change the type of the bootstrap.service

### DIFF
--- a/home.admin/assets/bootstrap.service
+++ b/home.admin/assets/bootstrap.service
@@ -8,7 +8,7 @@ After=network.target
 [Service]
 User=root
 Group=root
-Type=oneshot
+Type=simple
 RemainAfterExit=true
 ExecStart=/home/admin/_bootstrap.sh
 StandardOutput=journal

--- a/home.admin/assets/lnd.service
+++ b/home.admin/assets/lnd.service
@@ -10,7 +10,7 @@ After=bitcoind.service
 
 [Service]
 EnvironmentFile=
-ExecStart=/usr/local/bin/lnd
+ExecStart=/usr/local/bin/lnd --externalip=${publicIP}
 PIDFile=/home/bitcoin/.lnd/lnd.pid
 User=bitcoin
 Group=bitcoin


### PR DESCRIPTION
While tracking down the issue if the PublicIP that was not being updated, I've done some research on "systemd". Apparently with this one little change we will solve a lot of issues we had down the line. 

There is a service called "bootstrap.service" and another called "background.service". Both of those services are essential for certain tasks that run in the background. Furthermore "background.service" is dependent on "bootstrap.service" being up and running. 

On our setup the "bootstrap.service" wasn't running since it was started with the wrong "type" ("oneshot" instead of "simple"). This cause a lot of problems down the line e.g. PublicIP not updated, need to "sudo" all systemctl commands. Hope this solves some problems. 

More context regarding the topic:
https://stackoverflow.com/questions/39032100/what-is-the-difference-between-systemd-service-type-oneshot-and-simple
https://unix.stackexchange.com/questions/359941/starting-systemd-service-inside-systemd-service-causes-deadlock
